### PR TITLE
Validate inputs on /build-cfdi-from-json

### DIFF
--- a/app/Controllers/BuildCfdiFromJsonController.php
+++ b/app/Controllers/BuildCfdiFromJsonController.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace App\Controllers;
 
 use Dufrei\ApiJsonCfdiBridge\Factory;
+use Dufrei\ApiJsonCfdiBridge\JsonToXmlConverter\JsonToXmlConvertException;
+use Dufrei\ApiJsonCfdiBridge\PreCfdiSigner\UnableToSignXml;
+use Dufrei\ApiJsonCfdiBridge\StampService\StampException;
 use Dufrei\ApiJsonCfdiBridge\Values\CredentialCsd;
 use Dufrei\ApiJsonCfdiBridge\Values\JsonContent;
 use PhpCfdi\Credentials\Credential;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\HttpBadRequestException;
 use Slim\Psr7\Factory\StreamFactory;
+use Throwable;
 
 final class BuildCfdiFromJsonController
 {
@@ -22,18 +27,38 @@ final class BuildCfdiFromJsonController
 
     public function __invoke(Request $request, Response $response): Response
     {
-        $inputs = $request->getParsedBody();
+        $inputJson = $this->requestStringValue($request, 'json');
+        if ('' === $inputJson) {
+            throw (new HttpBadRequestException($request))->setTitle('Invalid json');
+        }
 
-        $json = new JsonContent(strval($inputs['json'] ?? ''));
-        $credential = Credential::create(
-            strval($inputs['certificate'] ?? ''),
-            strval($inputs['privatekey'] ?? ''),
-            strval($inputs['passphrase'] ?? ''),
-        );
+        $inputCertificate = $this->requestStringValue($request, 'certificate');
+        if ('' === $inputCertificate) {
+            throw (new HttpBadRequestException($request))->setTitle('Invalid certificate');
+        }
+
+        $inputPrivateKey = $this->requestStringValue($request, 'privatekey');
+        if ('' === $inputPrivateKey) {
+            throw (new HttpBadRequestException($request))->setTitle('Invalid private key');
+        }
+
+        $inputPassPhrase = $this->requestStringValue($request, 'passphrase');
+
+        try {
+            $credential = Credential::create($inputCertificate, $inputPrivateKey, $inputPassPhrase);
+        } catch (Throwable $exception) {
+            throw (new HttpBadRequestException($request, previous: $exception))
+                ->setTitle('Unable to create a credential using certificate, private key and passphrase');
+        }
+
+        $json = new JsonContent($inputJson);
         $csd = new CredentialCsd($credential);
-
         $action = $this->actionFactory->createBuildCfdiFromJsonAction();
-        $result = $action->execute($json, $csd);
+        try {
+            $result = $action->execute($json, $csd);
+        } catch (JsonToXmlConvertException|UnableToSignXml|StampException $exception) {
+            throw (new HttpBadRequestException($request, previous: $exception))->setTitle($exception->getMessage());
+        }
         $responseData = [
             'converted' => $result->getConvertedXml(),
             'sourcestring' => $result->getPreCfdi()->getSourceString(),
@@ -48,5 +73,14 @@ final class BuildCfdiFromJsonController
             ->withStatus(200)
             ->withHeader('Content-Type', 'application/json')
             ->withBody($responseBody);
+    }
+
+    private function requestStringValue(Request $request, string $input)
+    {
+        $value = $request->getParsedBody()[$input] ?? null;
+        if (! is_string($value)) {
+            return '';
+        }
+        return $value;
     }
 }

--- a/app/Middleware/AuthorizationMiddleware.php
+++ b/app/Middleware/AuthorizationMiddleware.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
-use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Exception\HttpUnauthorizedException;
 
 final class AuthorizationMiddleware implements MiddlewareInterface
 {
@@ -18,9 +18,7 @@ final class AuthorizationMiddleware implements MiddlewareInterface
         $token = new Token($this->obtainToken($request));
         $hash = $this->obtainHash();
         if (! $token->verify($hash)) {
-            return (new ResponseFactory())
-                ->createResponse(401)
-                ->withHeader('WWW-Authenticate', 'Bearer');
+            throw new HttpUnauthorizedException($request);
         }
         return $handler->handle($request);
     }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,7 +19,13 @@ return (function (): App {
         ->addArgument($container->get('environment'));
 
     $app = AppFactory::create(container: $container);
+
     $app->add($container->get(AuthorizationMiddleware::class));
+
+    $errorMiddleware = $app->addErrorMiddleware(displayErrorDetails: true, logErrors: false, logErrorDetails: false);
+    $errorHandler = $errorMiddleware->getDefaultErrorHandler();
+    $errorHandler->forceContentType('application/json');
+
     $app->post('/build-cfdi-from-json', BuildCfdiFromJsonController::class);
 
     return $app;

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "eclipxe/cfdiutils": "^2.15",
         "slim/slim": "^4.8",
         "slim/psr7": "^1.4",
-        "league/container": "^4.1"
+        "league/container": "^4.1",
+        "rakit/validation": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,6 +14,7 @@ la aplicación y se actualizan periódicamente?
 ## Probar los errores
 
 Ya se ha creado el endpoint `/build-cfdi-from-json`, falta validar los datos recibidos y los errores de proceso.
+Tal vez usando <https://github.com/selective-php/validation>.
 
 ## Registro
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,8 +13,7 @@ la aplicación y se actualizan periódicamente?
 
 ## Probar los errores
 
-Ya se ha creado el endpoint `/build-cfdi-from-json`, falta validar los datos recibidos y los errores de proceso.
-Tal vez usando <https://github.com/selective-php/validation>.
+Se necesita simular un error de comunicación con Finkok, este error no debe tratarse como un error 400.
 
 ## Registro
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -20,20 +20,20 @@ use PhpCfdi\Finkok\QuickFinkok;
 
 class Factory
 {
-    public function __construct(
+    final public function __construct(
         private Config $config
     ) {
     }
 
     /**
      * @param array<string, mixed>|null $environment
-     * @return self
+     * @return static
      */
     public static function create(array $environment = null): self
     {
         $builder = new ConfigBuilder($environment ?? $_ENV);
         $config = $builder->build();
-        return new self($config);
+        return new static($config);
     }
 
     public function createXmlResolver(): XmlResolver

--- a/tests/Fakes/FakeFactory.php
+++ b/tests/Fakes/FakeFactory.php
@@ -9,7 +9,7 @@ use Dufrei\ApiJsonCfdiBridge\StampService\StampServiceInterface;
 
 class FakeFactory extends Factory
 {
-    private ?StampServiceInterface $stampService;
+    private ?StampServiceInterface $stampService = null;
 
     public function setStampService(?StampServiceInterface $stampService): self
     {

--- a/tests/app/Controllers/BuildCfdiFromJsonControllerTest.php
+++ b/tests/app/Controllers/BuildCfdiFromJsonControllerTest.php
@@ -8,17 +8,38 @@ use App\Controllers\BuildCfdiFromJsonController;
 use App\Tests\TestCase;
 use Dufrei\ApiJsonCfdiBridge\Config;
 use Dufrei\ApiJsonCfdiBridge\Factory;
+use Dufrei\ApiJsonCfdiBridge\StampService\StampErrors;
+use Dufrei\ApiJsonCfdiBridge\StampService\StampException;
 use Dufrei\ApiJsonCfdiBridge\Tests\Fakes\FakeFactory;
 use Dufrei\ApiJsonCfdiBridge\Tests\Fakes\FakeStampService;
 use Dufrei\ApiJsonCfdiBridge\Values\Cfdi;
 use Dufrei\ApiJsonCfdiBridge\Values\Uuid;
 use Dufrei\ApiJsonCfdiBridge\Values\XmlContent;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 /**
  * @see BuildCfdiFromJsonController
  */
 final class BuildCfdiFromJsonControllerTest extends TestCase
 {
+    private function createValidFormRequestWithJson(string $json): Request
+    {
+        return $this->createFormRequest('POST', '/build-cfdi-from-json', $this->getTestingToken(), [
+            'json' => $json,
+            'certificate' => $this->fileContents('fake-csd/EKU9003173C9.cer'),
+            'privatekey' => $this->fileContents('fake-csd/EKU9003173C9.key'),
+            'passphrase' => trim($this->fileContents('fake-csd/EKU9003173C9-password.txt')),
+        ]);
+    }
+
+    private function setUpContainerWithFakeStampService(Cfdi|StampException|null $result = null): void
+    {
+        $factory = FakeFactory::create();
+        $stampService = new FakeStampService(array_filter([$result]));
+        $factory->setStampService($stampService);
+        $this->getContainer()->add(Factory::class, $factory);
+    }
+
     public function testBuildCfdiFromJsonUsingFakeStampService(): void
     {
         $cfdi = new Cfdi(
@@ -57,5 +78,86 @@ final class BuildCfdiFromJsonControllerTest extends TestCase
         $response = $this->getApp()->handle($request);
 
         $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testControllerValidatesJson(): void
+    {
+        $request = $this->createFormRequest('POST', '/build-cfdi-from-json', $this->getTestingToken());
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('Invalid json', json_decode((string) $response->getBody())->message);
+    }
+
+    public function testControllerValidatesCertificate(): void
+    {
+        $request = $this->createFormRequest('POST', '/build-cfdi-from-json', $this->getTestingToken(), [
+            'json' => '{}',
+        ]);
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('Invalid certificate', json_decode((string) $response->getBody())->message);
+    }
+
+    public function testControllerValidatesPrivateKey(): void
+    {
+        $request = $this->createFormRequest('POST', '/build-cfdi-from-json', $this->getTestingToken(), [
+            'json' => '{}',
+            'certificate' => 'CER',
+        ]);
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('Invalid private key', json_decode((string) $response->getBody())->message);
+    }
+
+    public function testControllerValidatesCredential(): void
+    {
+        $request = $this->createFormRequest('POST', '/build-cfdi-from-json', $this->getTestingToken(), [
+            'json' => '{}',
+            'certificate' => 'CER',
+            'privatekey' => 'KEY',
+        ]);
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(
+            'Unable to create a credential using certificate, private key and passphrase',
+            json_decode((string) $response->getBody())->message
+        );
+    }
+
+    public function testUnableToConvert(): void
+    {
+        $this->setUpContainerWithFakeStampService();
+        $request = $this->createValidFormRequestWithJson('invalid json');
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('Unable to parse JSON', json_decode((string) $response->getBody())->message);
+    }
+
+    public function testUnableToSignXml(): void
+    {
+        $this->setUpContainerWithFakeStampService();
+        // replace issuer rfc to produce error
+        $json = str_replace('EKU9003173C9', 'AAA010101AAA', $this->fileContents('invoice.json'));
+        $request = $this->createValidFormRequestWithJson($json);
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertStringContainsString('EKU9003173C9', json_decode((string) $response->getBody())->message);
+    }
+
+    public function testUnableToStampCfdi(): void
+    {
+        $stampException = new StampException('Fake message', new StampErrors());
+        $this->setUpContainerWithFakeStampService($stampException);
+        $request = $this->createValidFormRequestWithJson($this->fileContents('invoice.json'));
+        $response = $this->getApp()->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertStringContainsString('Fake message', json_decode((string) $response->getBody())->message);
     }
 }

--- a/tests/app/Controllers/BuildCfdiFromJsonControllerTest.php
+++ b/tests/app/Controllers/BuildCfdiFromJsonControllerTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Controllers;
 
 use App\Controllers\BuildCfdiFromJsonController;
 use App\Tests\TestCase;
-use Dufrei\ApiJsonCfdiBridge\Config;
 use Dufrei\ApiJsonCfdiBridge\Factory;
 use Dufrei\ApiJsonCfdiBridge\StampService\StampErrors;
 use Dufrei\ApiJsonCfdiBridge\StampService\StampException;
@@ -46,24 +45,12 @@ final class BuildCfdiFromJsonControllerTest extends TestCase
             new Uuid('CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC'),
             new XmlContent($this->fileContents('stamped.xml')),
         );
-        $factory = new FakeFactory($this->getContainer()->get(Config::class));
-        $factory->setStampService(new FakeStampService([$cfdi]));
-
-        // override factory to use a preset stamp service
-        $container = $this->getContainer();
-        $container->add(Factory::class, $factory);
-
-        $request = $this->createFormRequest('POST', '/build-cfdi-from-json', $this->getTestingToken(), [
-            'json' => $this->fileContents('invoice.json'),
-            'certificate' => $this->fileContents('fake-csd/EKU9003173C9.cer'),
-            'privatekey' => $this->fileContents('fake-csd/EKU9003173C9.key'),
-            'passphrase' => trim($this->fileContents('fake-csd/EKU9003173C9-password.txt')),
-        ]);
-
+        $this->setUpContainerWithFakeStampService($cfdi);
+        $request = $this->createValidFormRequestWithJson($this->fileContents('invoice.json'));
         $response = $this->getApp()->handle($request);
-        $responseData = json_decode((string) $response->getBody());
 
         $this->assertSame(200, $response->getStatusCode());
+        $responseData = json_decode((string) $response->getBody());
         $this->assertStringEqualsFile($this->filePath('converted.xml'), $responseData->converted);
         $this->assertStringEqualsFile($this->filePath('sourcestring.txt'), $responseData->sourcestring);
         $this->assertStringEqualsFile($this->filePath('signed.xml'), $responseData->precfdi);
@@ -74,7 +61,6 @@ final class BuildCfdiFromJsonControllerTest extends TestCase
     public function testControllerAccessUsesToken(): void
     {
         $request = $this->createFormRequest('POST', '/build-cfdi-from-json');
-
         $response = $this->getApp()->handle($request);
 
         $this->assertSame(401, $response->getStatusCode());
@@ -141,8 +127,9 @@ final class BuildCfdiFromJsonControllerTest extends TestCase
 
     public function testUnableToStampCfdi(): void
     {
-        $stampException = new StampException('Fake message', new StampErrors());
-        $this->setUpContainerWithFakeStampService($stampException);
+        $this->setUpContainerWithFakeStampService(
+            new StampException('Fake message', new StampErrors())
+        );
         $request = $this->createValidFormRequestWithJson($this->fileContents('invoice.json'));
         $response = $this->getApp()->handle($request);
 


### PR DESCRIPTION
- Add `rakit/validation` as validation dependency
- Invalid inputs produce errors with status 400
- Error structure is `{message: "Invalid input", errors: [ <field>: <error> ]}`