### PR TITLE
Minimal project fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,5 +16,5 @@
 /.php-cs-fixer.dist.php     export-ignore
 /.scrutinizer.yml           export-ignore
 /phpcs.xml.dist             export-ignore
-/phpstan.xml.dist           export-ignore
+/phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.1.0" installed="3.1.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.2.1" installed="3.2.1" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.6.0" installed="3.6.0" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.0" installed="3.6.0" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^0.12.90" installed="0.12.96" location="./tools/phpstan" copy="false"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
-## Version 1.0.0
+## Versión 1.0.1
+
+- Corrección de sintaxis en el archivo `Dockerfile`.
+- Corregir el nombre del archivo de configuración de phpstan en `.gitattributes`.
+- Actualización y corrección de estilo de `php-cs-fixer: 3.2.1`.
+
+## Versión 1.0.0
 
 - Versión inicial.

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -59,7 +59,7 @@ class Factory
      */
     public function createStampService(bool $asProduction = null): StampServiceInterface
     {
-        $asProduction = $asProduction ?? $this->config->isFinkokOnProduction();
+        $asProduction ??= $this->config->isFinkokOnProduction();
         $environment = $asProduction ? FinkokEnvironment::makeProduction() : FinkokEnvironment::makeDevelopment();
         $settings = new FinkokSettings(
             $this->config->getFinkokUsername(),
@@ -74,8 +74,8 @@ class Factory
         ?XmlResolver $xmlResolver = null,
         ?XsltBuilderInterface $xsltBuilder = null,
     ): SignXmlAction {
-        $xmlResolver = $xmlResolver ?? $this->createXmlResolver();
-        $xsltBuilder = $xsltBuilder ?? $this->createXsltBuilder();
+        $xmlResolver ??= $this->createXmlResolver();
+        $xsltBuilder ??= $this->createXsltBuilder();
         return new SignXmlAction($xmlResolver, $xsltBuilder);
     }
 
@@ -90,7 +90,7 @@ class Factory
         ?XsltBuilderInterface $xsltBuilder = null,
         ?StampServiceInterface $stampService = null,
     ): BuildCfdiFromJsonAction {
-        $stampService = $stampService ?? $this->createStampService();
+        $stampService ??= $this->createStampService();
         return new BuildCfdiFromJsonAction(
             new ConvertJsonToXmlAction(),
             $this->createSignXmlAction($xmlResolver, $xsltBuilder),


### PR DESCRIPTION
- Corregir el nombre del archivo de configuración de phpstan en `.gitattributes`.
- Actualización y corrección de estilo de `php-cs-fixer: 3.2.1`.

Se agrega en el changelog

- Corrección de sintaxis en el archivo `Dockerfile`.
